### PR TITLE
Changes to support page redirects during tests

### DIFF
--- a/include/CefTestApp.h
+++ b/include/CefTestApp.h
@@ -42,13 +42,13 @@ public:
 
     static void SetTestBrowser(CefRefPtr<CefBrowser> b);
     static CefRefPtr<CefBrowser> GetTestBrowser();
+    static void ClearTestBrowser();
     struct NoTestBrowserConfigured {};
     struct TestBrowserAlreadyConfigured {};
 
     static void SetTestContext(CefRefPtr<CefV8Context> b);
     static CefRefPtr<CefV8Context> GetTestContext();
     struct NoTestContextConfigured {};
-    struct TestContextAlreadyConfigured {};
 private:
     static CefRefPtr<CefBrowser> testBrowser;
     static CefRefPtr<CefV8Context> testContext;

--- a/include/CefTestAppHandlers.h
+++ b/include/CefTestAppHandlers.h
@@ -53,6 +53,7 @@ private:
     int argc;
     char ** argv;
     static bool exitClean;
+    bool running;
     DummyCefApp& app;
 
 	IMPLEMENT_REFCOUNTING(DummyCefAppHandlers);

--- a/libTest/CefTestApp.cpp
+++ b/libTest/CefTestApp.cpp
@@ -84,13 +84,13 @@ void DummyCefApp::SetTestBrowser(CefRefPtr<CefBrowser> b) {
         DummyCefApp::testBrowser = b;
     }
 }
+void DummyCefApp::ClearTestBrowser() {
+    DummyCefApp::testBrowser = nullptr;
+}
+
 
 void DummyCefApp::SetTestContext(CefRefPtr<CefV8Context> c) {
-    if (testContext.get()) {
-        throw TestContextAlreadyConfigured{};
-    } else {
-        testContext = c;
-    }
+    testContext = c;
 }
 
 CefRefPtr<CefV8Context> DummyCefApp::GetTestContext() {

--- a/libTest/CefTestClient.cpp
+++ b/libTest/CefTestClient.cpp
@@ -1,3 +1,4 @@
+#include <CefTestApp.h>
 #include "CefTestClient.h"
 #include "logger.h"
 #include "CefTestAppHandlers.h"
@@ -18,6 +19,7 @@ void DummyCefClient::OnAfterCreated(CefRefPtr<CefBrowser> _browser) {
         abort();
     }
     browser = _browser;
+    DummyCefApp::SetTestBrowser(browser);
 }
 
 

--- a/test/cookie.cpp
+++ b/test/cookie.cpp
@@ -47,7 +47,6 @@ public:
                      const std::string& value,
                      const CefBaseCookies::RemainingCookies& status)
         {
-            std::cout << ">> Got: " << name << std::endl;
             if (status != CefBaseCookies::RemainingCookies::NO_COOKIES) {
                 cookieString->append(name);
                 cookieString->append("=");
@@ -87,9 +86,7 @@ public:
         auto cookieString = std::make_shared<std::string>();
         std::shared_ptr<CefBaseIPCExec::IIPC_AsyncResult> sharedResult(result.release());
 
-        std::cout << "Requesting Map!" << std::endl;
         mgr->GetCookieMap(url, [=] (std::shared_ptr<const CefBaseCookies::CookieNameValueMap> cookies) -> void {
-            std::cout << "Got Map!" << std::endl;
             for (auto it = cookies->begin(); it != cookies->end(); ++it) {
                 const std::string& name = it->first;
                 const std::string& value = it->second;


### PR DESCRIPTION
 - Provide the test browser on the browser process
 - Update the context creation handling to support
   a change context

Note that it was necessary to clear it before exiting the event loop.
Having a live CefBrowser during process clean down seems to result in a
crash on exit